### PR TITLE
Corrected test name

### DIFF
--- a/app/Http/Controllers/PerformanceController.php
+++ b/app/Http/Controllers/PerformanceController.php
@@ -10,7 +10,7 @@ class PerformanceController extends Controller
     public function listAll()
     {
         $tests = [
-            'Request Time',
+            'Response Time',
         ];
 
         $response = new Response();


### PR DESCRIPTION
Corrected 'Request Time' to 'Response Time' in /tests/performance/listAll to match the endpoint